### PR TITLE
Use price instead of price_with_currency

### DIFF
--- a/templates/show.liquid
+++ b/templates/show.liquid
@@ -146,7 +146,7 @@ File: show.liquid
     {% for variant in product_variants %}
       {% capture first_index %}{{ forloop.index0 }}{% endcapture %}
       window.product_variants[{{ first_index }}] = {
-        "price": "{{ variant.price_with_currency }}",
+        "price": "{{ variant.price }}",
         "options_text": "{{ variant.options_text }}",
         "image": "{{ variant.featured_image.src }}"
         };


### PR DESCRIPTION
Hey @etagwerker, @alanhala, @cecilia-ombulabs, 

We were using `variant.price_with_currency` instead of `variant.price` for `show.liquid`, and the `application.js` file for each theme was expecting the value to be an integer instead of a string. 

Fixes the problem where the product price is displayed instead of each variant’s price.

Please check it out, thanks!
