### PR TITLE
Use parseFloat and round instead of using floor on price.

### DIFF
--- a/javascripts/application.js
+++ b/javascripts/application.js
@@ -49,7 +49,7 @@ function checkSelected() {
 
 function changePrice(price){
   if(price != undefined && price != "") {
-    $("span.price").html("$"+Math.floor(price));
+    $("span.price").html("$"+parseFloat(price).toFixed(2));
   }
 }
 


### PR DESCRIPTION
Hey @etagwerker, @lubc, 

This PR fixes the problem with price units as seen in http://demo.ombushop.com/products/camisa-a-cuadros. We're currently applying `Math.float` via JS on prices when we shouldn't be. 

Please check it out, thanks! 